### PR TITLE
Added show Ids to scrobble request

### DIFF
--- a/Source/Lib/Trakt.NET/Modules/TraktScrobbleModule.cs
+++ b/Source/Lib/Trakt.NET/Modules/TraktScrobbleModule.cs
@@ -336,7 +336,8 @@
                 Show = show != null
                     ? new TraktShow
                       {
-                          Title = show.Title
+                          Title = show.Title,
+                          Ids = show.Ids
                       }
                     : null,
                 Progress = progress


### PR DESCRIPTION
Hi,

During episode start/stop the lib only sends the title of the tv show when I call `Start/StopEpisodeWithShowAsync` and in some cases this leads to a 404 response from Trakt.
I've made a little modification to include the available ids of the tv show for these API calls. This reduced the 404s in my case.